### PR TITLE
docs(loading-overlay): documenta como utilizar p-screen-lock="false"

### DIFF
--- a/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
+++ b/projects/ui/src/lib/components/po-loading/po-loading-overlay/po-loading-overlay-base.component.ts
@@ -38,7 +38,20 @@ export class PoLoadingOverlayBaseComponent {
    *
    * @description
    *
-   * Define se o _overlay_ será aplicado a um container ou a página inteira.
+   * Define se o *overlay* será aplicado a um *container* ou a página inteira.
+   *
+   * Para utilizar o componente como um *container*, o elemento pai deverá receber uma posição relativa, por exemplo:
+   *
+   * ```
+   * <div style="position: relative">
+   *
+   *  <po-chart [p-series]="[{ value: 10, category: 'Example' }]">
+   *  </po-chart>
+   *
+   *  <po-loading-overlay>
+   *  </po-loading-overlay>
+   * </div>
+   * ```
    *
    * @default `false`
    */


### PR DESCRIPTION
Para o correto funcionamento no uso da propriedade p-screen-lock="false"
é necessário que o elemento pai tenha uma posição relativa para limitar
seu container de carregamento, que possui uma posição absoluta.

Fixes DTHFUI-2602

**< COMPONENTE >**

**< NÚMERO DA ISSUE >**
_____________________________________________________________________________

**PR Checklist**

- [ ] Código
- [ ] Testes unitários
- [ ] Documentação
- [ ] Samples

**Qual o comportamento atual?**


**Qual o novo comportamento?**


**Simulação**
